### PR TITLE
chore: Update contributing.md completing Hard Cryptic Clues

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -60,6 +60,6 @@ Most areas are square:
 
 ### Adding Cryptic Clue Data
 - [ ] [Easy Cryptic Clue Steps Thread](https://github.com/Daniel-Tudose/True-Clue-Dig-Locations/issues/15)
-- [ ] [Hard Cryptic Clue Steps Thread](https://github.com/Daniel-Tudose/True-Clue-Dig-Locations/issues/16)
+- [x] [Hard Cryptic Clue Steps Thread](https://github.com/Daniel-Tudose/True-Clue-Dig-Locations/issues/16)
 - [ ] [Elite Cryptic Clue Steps Thread](https://github.com/Daniel-Tudose/True-Clue-Dig-Locations/issues/22)
 - [ ] [Master Cryptic Clue Steps Thread](https://github.com/Daniel-Tudose/True-Clue-Dig-Locations/issues/17)


### PR DESCRIPTION
### chore: Update contributing.md completing Hard Cryptic Clues
Updated the Contributing guide to reflect no more Hard Cryptic Clue (dig) steps needed for verification


Additionally, the README says Cryptic Hard Clues are 100% implemented and there are no listed steps requiring verification within #16. 
<img width="866" height="339" alt="image" src="https://github.com/user-attachments/assets/b98ca19b-dd4d-42ea-8521-31ccebe6bd19" />
